### PR TITLE
Dialpad is checking every minute CallForwarding status

### DIFF
--- a/src/calls/components/CallForwarding/CallForwardingBanner.js
+++ b/src/calls/components/CallForwarding/CallForwardingBanner.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { View, Text } from 'react-native';
 import { Icon } from 'react-native-elements';
 
-function CallForwardingBanner({ callForwarding }) {
+const CallForwardingBanner = ({ callForwarding }) => {
   if (
     callForwarding['simultaneous-ring'] ||
     callForwarding['call-forwarding']
@@ -32,6 +32,6 @@ function CallForwardingBanner({ callForwarding }) {
     );
   }
   return null;
-}
+};
 
 export default CallForwardingBanner;

--- a/src/calls/screens/DialpadScreen/DialpadScreen.js
+++ b/src/calls/screens/DialpadScreen/DialpadScreen.js
@@ -49,11 +49,19 @@ const DialpadScreen = ({
   onCall,
   connected,
   navigation,
-  activeNumber
+  activeNumber,
+  getCallForwardingStatus
 }) => {
   useEffect(() => {
+    let timer = setInterval(() => {
+      console.log('Getting callforwarding status');
+      getCallForwardingStatus(activeNumber);
+    }, 60000);
     navigation.navigate(connected ? 'AppRegistered' : 'Register');
     console.log('Running useEffect -> DialpadScreen()');
+    return function cleanup() {
+      clearInterval(timer);
+    };
   }, [connected]);
 
   if (onCall) {
@@ -115,7 +123,7 @@ DialpadScreen.propTypes = {
   tempRemote: PropTypes.shape({
     phoneNumber: PropTypes.string
   }),
-  activeNumber: PropTypes.bool.isRequired
+  activeNumber: PropTypes.string.isRequired
 };
 
 DialpadScreen.defaultProps = {

--- a/src/calls/screens/DialpadScreen/DialpadScreenContainer.js
+++ b/src/calls/screens/DialpadScreen/DialpadScreenContainer.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
-
+import { bindActionCreators } from 'redux';
 import ConnectedScreen from './DialpadScreen';
+import dialBackendApi from '../../../services/api';
 
 function mapStateToProps({ call, connection, numbers }) {
   return {
@@ -13,4 +14,16 @@ function mapStateToProps({ call, connection, numbers }) {
   };
 }
 
-export default connect(mapStateToProps)(ConnectedScreen);
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators(
+    {
+      getCallForwardingStatus: dialBackendApi().getCallForwardingStatus
+    },
+    dispatch
+  );
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ConnectedScreen);


### PR DESCRIPTION
DialpadScreen seems to never unmount, so I put an interval of 60 seconds calling getCallForwardingStatus.
If DialpadScreen unmount, Interval is cleared.
It's working even if you navigate through screens.