### PR TITLE
Able to switch phone number without having to logout

### DIFF
--- a/__tests__/SwitchNumbers.js
+++ b/__tests__/SwitchNumbers.js
@@ -1,0 +1,48 @@
+/**
+ * @format
+ * @lint-ignore-every XPLATJSCOPYRIGHT1
+ */
+
+import 'react-native';
+import React from 'react';
+import SwitchNumbersScreen from '../src/calls/screens/SwitchNumbersScreen/SwitchNumbersScreen';
+
+// Note: test renderer must be required after react-native.
+import renderer from 'react-test-renderer';
+
+it('renders correctly', () => {
+  renderer.create(
+    <SwitchNumbersScreen
+      unregister={() => null}
+      navigation={{ navigate: () => null }}
+    />
+  );
+});
+
+it('redirect to Register', () => {
+  let navigate = false;
+  renderer.create(
+    <SwitchNumbersScreen
+      unregister={() => null}
+      navigation={{
+        navigate: (to) => {
+          navigate = to;
+        }
+      }}
+    />
+  );
+  expect(navigate).toBe('Register');
+});
+
+it('Displays a redirecting message', () => {
+  const rendered = renderer.create(
+    <SwitchNumbersScreen
+      unregister={() => null}
+      navigation={{
+        navigate: () => null
+      }}
+    />
+  );
+  const json = rendered.toJSON();
+  expect(json.children[0]).toContain('Redirecting');
+});

--- a/src/calls/navigators/index.js
+++ b/src/calls/navigators/index.js
@@ -9,6 +9,7 @@ import RegisterLoadingScreenContainer from '../screens/RegisterLoadingScreen/Reg
 import RegisterStack from './register';
 import ContactsStack from './contacts';
 import ColorPalette from '../../styles/ColorPalette';
+import SwitchNumbersScreenContainer from '../screens/SwitchNumbersScreen/SwitchNumbersScreenContainer';
 
 export const AppStack = createMaterialBottomTabNavigator(
   {
@@ -51,6 +52,7 @@ export const AppStack = createMaterialBottomTabNavigator(
 export const AppFullStack = createSwitchNavigator(
   {
     RegisterLoading: RegisterLoadingScreenContainer,
+    SwitchNumbers: SwitchNumbersScreenContainer,
     AppRegistered: AppStack,
     Register: RegisterStack
   },

--- a/src/calls/screens/DialpadScreen/DialpadScreen.js
+++ b/src/calls/screens/DialpadScreen/DialpadScreen.js
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, View, Alert } from 'react-native';
 import { Icon, Text } from 'react-native-elements';
 import { withNavigation } from 'react-navigation';
 import MakeCallForm from '../../components/DialpadForm/DialpadForm';
@@ -108,6 +108,24 @@ const DialpadScreen = ({
             color: 'white',
             overflow: 'hidden'
           }}
+          onPress={() =>
+            Alert.alert(
+              'Switch number',
+              'Do you really want to switch numbers ?',
+              [
+                {
+                  text: 'Cancel',
+                  onPress: () => null,
+                  style: 'cancel'
+                },
+                {
+                  text: 'Yes',
+                  onPress: () => navigation.navigate('SwitchNumbers')
+                }
+              ],
+              { cancelable: false }
+            )
+          }
         >
           {activeNumber}
         </Text>

--- a/src/calls/screens/SwitchNumbersScreen/SwitchNumbersScreen.js
+++ b/src/calls/screens/SwitchNumbersScreen/SwitchNumbersScreen.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Text } from 'react-native-elements';
+
+export default function SwitchNumbersScreen({ unregister, navigation }) {
+  unregister();
+  navigation.navigate('Register');
+
+  return (
+    <Text
+      style={{ fontSize: 25, width: '100%', height: '100%', padding: '5%' }}
+    >
+      {'Redirecting you to the register screen...'}
+    </Text>
+  );
+}

--- a/src/calls/screens/SwitchNumbersScreen/SwitchNumbersScreenContainer.js
+++ b/src/calls/screens/SwitchNumbersScreen/SwitchNumbersScreenContainer.js
@@ -1,0 +1,15 @@
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { connectionActions } from 'dial-core';
+import SwitchNumbersScreen from './SwitchNumbersScreen';
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators(
+    {
+      unregister: connectionActions.setDisconnectionSuccess
+    },
+    dispatch
+  );
+}
+
+export default connect(null, mapDispatchToProps)(SwitchNumbersScreen);

--- a/src/settings/navigators/settings.js
+++ b/src/settings/navigators/settings.js
@@ -5,6 +5,7 @@ import ColorPalette from '../../styles/ColorPalette';
 import ProfileContainer from '../components/profile/ProfileContainer';
 import RegisterScreenContainer from '../../calls/screens/RegisterScreen/RegisterScreenContainer';
 import CallForwardingScreenContainer from '../screens/CallForwardingScreen/CallForwardingScreenContainer';
+import SwitchNumbersScreenContainer from '../../calls/screens/SwitchNumbersScreen/SwitchNumbersScreenContainer';
 import SearchUsersScreenForwardingContainer from '../../calls/screens/SearchUsersScreen/SearchUsersScreenForwardingContainer';
 import DestinationsRingingListContainer from '../screens/CallForwardingScreen/DestinationsListRingingContainer';
 import DestinationsListForwardContainer from '../screens/CallForwardingScreen/DestinationsListForwardContainer';
@@ -65,6 +66,22 @@ const SettingsStack = createStackNavigator({
     navigationOptions: () => {
       return {
         title: `Call Forwarding Settings`,
+        headerTitleStyle: {
+          flex: 3
+        },
+        headerStyle: {
+          backgroundColor: ColorPalette.primary,
+          flex: 3
+        },
+        headerTintColor: 'white'
+      };
+    }
+  },
+  SwitchNumers: {
+    screen: SwitchNumbersScreenContainer,
+    navigationOptions: () => {
+      return {
+        title: `Switch Numbers`,
         headerTitleStyle: {
           flex: 3
         },

--- a/src/settings/screens/SettingsScreen/SettingsScreen.js
+++ b/src/settings/screens/SettingsScreen/SettingsScreen.js
@@ -19,6 +19,13 @@ export default class SettingsScreen extends React.Component {
         }
       },
       {
+        title: 'Switch phone numbers',
+        icon: 'phone',
+        onPress: () => {
+          navigation.navigate('SwitchNumbers');
+        }
+      },
+      {
         title: 'Call Forwarding',
         icon: 'phone-forwarded',
         onPress: () => {


### PR DESCRIPTION
If you click on the `green label containing your current activeNumber` you will have a message asking you if you really want to go to the register screen.
You can also go to the settings and click on `Switch phone numbers`.

In both case you will be redirected to the `registerScreen`.

resolve #75 